### PR TITLE
Add support for value objects as data

### DIFF
--- a/src/components/Trend/__test__/Trend.test.js
+++ b/src/components/Trend/__test__/Trend.test.js
@@ -79,4 +79,24 @@ describe('Trend', () => {
     expect(lastStopProps.offset).toEqual(1);
     expect(lastStopProps.stopColor).toEqual('red');
   });
+
+  it('handles an array of value objects', () => {
+    // We'll check that it renders identical output for both types.
+    const data = {
+      numbers: [1, 5, 1],
+      objects: [{ value: 1 }, { value: 5 }, { value: 1 }],
+    };
+
+    const numberWrapper = shallow(<Trend data={data.numbers} />);
+    const objectWrapper = shallow(<Trend data={data.objects} />);
+
+    // Compare the actual path rendered, not the entire HTML output.
+    // This is because trends are given randomly-generated IDs, and
+    // an ID prop is applied to the <path>, making equality checks fail.
+    expect(
+      numberWrapper.childAt(0).props().d
+    ).toEqual(
+      objectWrapper.childAt(0).props().d
+    );
+  });
 });

--- a/stories/data.stories.js
+++ b/stories/data.stories.js
@@ -117,3 +117,17 @@ storiesOf('Trend data', module)
       style={{ display: 'block' }}
     />
   ))
+  .add('as an array of objects', () => (
+    <Trend
+      data={[
+        { value: 1 },
+        { value: 5 },
+        { value: 2 },
+        { value: 3 },
+        { value: 1 },
+        { value: 5 },
+        { value: 1 },
+      ]}
+      style={{ display: 'block' }}
+    />
+  ))


### PR DESCRIPTION
#### Overview

- Adds support for value objects `{ value: 4 }` in addition to simple numbers for the `data` prop.