### PR TITLE
Allow multiple trends to use different gradients

### DIFF
--- a/src/components/Trend/Trend.js
+++ b/src/components/Trend/Trend.js
@@ -40,8 +40,6 @@ const defaultProps = {
   autoDrawEasing: 'ease',
 };
 
-const GRADIENT_ID = 'react-trend-vertical-gradient';
-
 class Trend extends Component {
   constructor(props) {
     super(props);
@@ -50,6 +48,7 @@ class Trend extends Component {
     // Trend components on a page, so that they can have different keyframe
     // animations.
     this.trendId = generateId();
+    this.gradientId = `react-trend-vertical-gradient-${this.trendId}`;
   }
 
   componentDidMount() {
@@ -78,7 +77,13 @@ class Trend extends Component {
 
     return (
       <defs>
-        <linearGradient id={GRADIENT_ID} x1="0%" y1="0%" x2="0%" y2="100%">
+        <linearGradient
+          id={this.gradientId}
+          x1="0%"
+          y1="0%"
+          x2="0%"
+          y2="100%"
+        >
           {gradient.slice().reverse().map((c, index) => (
             <stop
               key={index}
@@ -161,7 +166,7 @@ class Trend extends Component {
           id={`react-trend-${this.trendId}`}
           d={path}
           fill="none"
-          stroke={gradient ? `url(#${GRADIENT_ID})` : undefined}
+          stroke={gradient ? `url(#${this.gradientId})` : undefined}
         />
       </svg>
     );

--- a/stories/multiple-trends.stories.js
+++ b/stories/multiple-trends.stories.js
@@ -62,3 +62,23 @@ storiesOf('Multiple trends', module)
       />
     </div>
   ))
+  .add('2 trends with different gradients', () => (
+    <div>
+      <Trend
+        autoDraw
+        autoDrawDuration={3000}
+        strokeWidth={3}
+        gradient={['purple', 'violet']}
+        data={[0, 10, 2, 8, 0, 5, 9, 2, 4, 0]}
+        style={{ display: 'block' }}
+      />
+      <Trend
+        autoDraw
+        autoDrawDuration={3000}
+        strokeWidth={3}
+        gradient={['orange', 'red']}
+        data={[0, 10, 2, 8, 0, 5, 9, 2, 4, 0]}
+        style={{ display: 'block' }}
+      />
+    </div>
+  ))


### PR DESCRIPTION
#### Overview

Previously, the ID used for the SVG's `<linearGradient>` was a constant. This had the unfortunate flaw of assigning the same ID to all gradients across the page, and as a result, multiple Trends would all share the same gradient, even if different values were supplied.

This change fixes it by generating the ID based on the Trend ID.
- Closes #6 

#### Screenshots/Videos (User Facing Changes)

<img width="900" alt="screen shot 2017-03-08 at 11 09 33 am" src="https://cloud.githubusercontent.com/assets/6692932/23712073/bcc975f0-03ef-11e7-8b5b-b7ed46bde070.png">
