### PR TITLE
Add support for straight lines

### DIFF
--- a/src/components/Trend/Trend.helpers.js
+++ b/src/components/Trend/Trend.helpers.js
@@ -7,8 +7,8 @@ export const normalizeDataset = (data, { minX, maxX, minY, maxY }) => {
   // X axis is easy: just evenly-space each item in the array.
   // For the Y axis, we first need to find the min and max of our array,
   // and then normalize those values between 0 and 1.
-  const boundariesY = { min: Math.min(...data), max: Math.max(...data) };
   const boundariesX = { min: 0, max: data.length - 1 };
+  const boundariesY = { min: Math.min(...data), max: Math.max(...data) };
 
   return data.map((point, index) => ({
     x: normalize({

--- a/src/helpers/__test__/math.helpers.test.js
+++ b/src/helpers/__test__/math.helpers.test.js
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import { getDistanceBetween } from '../math.helpers';
+import { getDistanceBetween, normalize } from '../math.helpers';
 
 describe('Math Helpers', () => {
   describe('getDistanceBetween', () => {
@@ -9,6 +9,60 @@ describe('Math Helpers', () => {
       const p2 = { x: 4, y: 3 };
 
       expect(getDistanceBetween(p1, p2)).toEqual(5);
+    });
+  });
+
+  describe('normalize', () => {
+    it('normalizes a value within a range', () => {
+      const value = 5;
+      const min = 0;
+      const max = 10;
+
+      expect(normalize({ value, min, max })).toEqual(0.5);
+    });
+
+    it('normalizes a value at the bottom of the range', () => {
+      const value = 0;
+      const min = 0;
+      const max = 10;
+
+      expect(normalize({ value, min, max })).toEqual(0);
+    });
+
+    it('normalizes a value at the top of the range', () => {
+      const value = 10;
+      const min = 0;
+      const max = 10;
+
+      expect(normalize({ value, min, max })).toEqual(1);
+    });
+
+    it('normalizes a value with a custom scale', () => {
+      const value = 5;
+      const min = 0;
+      const max = 10;
+      const scaleMin = 10;
+      const scaleMax = 20;
+
+      expect(
+        normalize({ value, min, max, scaleMin, scaleMax })
+      ).toEqual(15);
+    });
+
+    it('normalizes a value outside the range', () => {
+      const value = -5;
+      const min = 0;
+      const max = 10;
+
+      expect(normalize({ value, min, max })).toEqual(-0.5);
+    });
+
+    it('normalizes a value when min and max are equal', () => {
+      const value = 5;
+      const min = 5;
+      const max = min;
+
+      expect(normalize({ value, min, max })).toEqual(0);
     });
   });
 });

--- a/src/helpers/math.helpers.js
+++ b/src/helpers/math.helpers.js
@@ -11,9 +11,15 @@
  *
  * @returns {Number} the value on its new scale
  */
-export const normalize = ({ value, min, max, scaleMin = 0, scaleMax = 1 }) => (
-  scaleMin + (value - min) * (scaleMax - scaleMin) / (max - min)
-);
+export const normalize = ({ value, min, max, scaleMin = 0, scaleMax = 1 }) => {
+  // If the `min` and `max` are the same value, it means our dataset is flat.
+  // For now, let's assume that flat data should be aligned to the bottom.
+  if (min === max) {
+    return scaleMin;
+  }
+
+  return scaleMin + (value - min) * (scaleMax - scaleMin) / (max - min);
+};
 
 /** moveTo
  * the coordinate that lies at a midpoint between 2 lines, based on the radius

--- a/stories/data.stories.js
+++ b/stories/data.stories.js
@@ -117,6 +117,12 @@ storiesOf('Trend data', module)
       style={{ display: 'block' }}
     />
   ))
+  .add('same-value points', () => (
+    <Trend
+      data={[5, 5, 5, 5, 5, 5, 5, 5, 5, 5]}
+      style={{ display: 'block' }}
+    />
+  ))
   .add('as an array of objects', () => (
     <Trend
       data={[


### PR DESCRIPTION
#### Overview

- Fix a bug that was causing Trends composed of same-value data to crash.
- Closes #9

#### Notes

This solution will align the line at the bottom of the SVG. For values like 0, this makes sense (and is the most likely situation). However, sometimes the user might want this line to be at the top, or somewhere in the middle.

In a future PR, I'd like to add `min` and `max` props that will set a strict scale, instead of normalizing based on the dataset. With these props, the line would be positioned based on the single value's position between min/max.

For now, though, I think this solves most issues.

#### Screenshots/Videos (User Facing Changes)

![screen shot 2017-03-09 at 5 19 00 pm](https://cloud.githubusercontent.com/assets/6692932/23773282/83f1351c-04ec-11e7-8e20-199b72ee5c9a.png)
