### PR TITLE
Add hack to handle flat lines with gradients

### DIFF
--- a/src/components/Trend/Trend.helpers.js
+++ b/src/components/Trend/Trend.helpers.js
@@ -31,13 +31,13 @@ export const normalizeDataset = (data, { minX, maxX, minY, maxY }) => {
   // linear gradients applied. This means that our lines are invisible when
   // the dataset is flat (eg. [0, 0, 0, 0]).
   //
-  // The hacky solution is to apply a very slight offset to the final point of
+  // The hacky solution is to apply a very slight offset to the first point of
   // the dataset. As ugly as it is, it's the best solution we can find (there
   // are ways within the SVG spec of changing it, but not without causing
   // breaking changes).
   if (boundariesY.min === boundariesY.max) {
     // eslint-disable-next-line no-param-reassign
-    normalizedData[normalizedData.length - 1].y += 0.0001;
+    normalizedData[0].y += 0.0001;
   }
 
   return normalizedData;

--- a/src/components/Trend/Trend.helpers.js
+++ b/src/components/Trend/Trend.helpers.js
@@ -10,7 +10,7 @@ export const normalizeDataset = (data, { minX, maxX, minY, maxY }) => {
   const boundariesX = { min: 0, max: data.length - 1 };
   const boundariesY = { min: Math.min(...data), max: Math.max(...data) };
 
-  return data.map((point, index) => ({
+  const normalizedData = data.map((point, index) => ({
     x: normalize({
       value: index,
       min: boundariesX.min,
@@ -26,6 +26,21 @@ export const normalizeDataset = (data, { minX, maxX, minY, maxY }) => {
       scaleMax: maxY,
     }),
   }));
+
+  // According to the SVG spec, paths with a height/width of `0` can't have
+  // linear gradients applied. This means that our lines are invisible when
+  // the dataset is flat (eg. [0, 0, 0, 0]).
+  //
+  // The hacky solution is to apply a very slight offset to the final point of
+  // the dataset. As ugly as it is, it's the best solution we can find (there
+  // are ways within the SVG spec of changing it, but not without causing
+  // breaking changes).
+  if (boundariesY.min === boundariesY.max) {
+    // eslint-disable-next-line no-param-reassign
+    normalizedData[normalizedData.length - 1].y += 0.0001;
+  }
+
+  return normalizedData;
 };
 
 export const generateAutoDrawCss = ({ id, lineLength, duration, easing }) => {

--- a/src/components/Trend/__test__/Trend.helpers.test.js
+++ b/src/components/Trend/__test__/Trend.helpers.test.js
@@ -57,5 +57,24 @@ describe('Trend Helpers', () => {
 
       expect(actualResult).toEqual(expectedResult);
     });
+
+    it('handles same-value data', () => {
+      const data = [5, 5, 5, 5, 5];
+      const minX = 0;
+      const maxX = 100;
+      const minY = 0;
+      const maxY = 10;
+
+      const expectedResult = [
+        { x: 0, y: 0 },
+        { x: 25, y: 0 },
+        { x: 50, y: 0 },
+        { x: 75, y: 0 },
+        { x: 100, y: 0.0001 },
+      ];
+      const actualResult = normalizeDataset(data, { minX, maxX, minY, maxY });
+
+      expect(actualResult).toEqual(expectedResult);
+    });
   });
 });

--- a/src/components/Trend/__test__/Trend.helpers.test.js
+++ b/src/components/Trend/__test__/Trend.helpers.test.js
@@ -66,11 +66,11 @@ describe('Trend Helpers', () => {
       const maxY = 10;
 
       const expectedResult = [
-        { x: 0, y: 0 },
+        { x: 0, y: 0.0001 },
         { x: 25, y: 0 },
         { x: 50, y: 0 },
         { x: 75, y: 0 },
-        { x: 100, y: 0.0001 },
+        { x: 100, y: 0 },
       ];
       const actualResult = normalizeDataset(data, { minX, maxX, minY, maxY });
 

--- a/stories/data.stories.js
+++ b/stories/data.stories.js
@@ -123,6 +123,13 @@ storiesOf('Trend data', module)
       style={{ display: 'block' }}
     />
   ))
+  .add('same-value points, with gradient', () => (
+    <Trend
+      data={[5, 5, 5, 5, 5, 5, 5, 5, 5, 5]}
+      gradient={['red', 'orange']}
+      style={{ display: 'block' }}
+    />
+  ))
   .add('as an array of objects', () => (
     <Trend
       data={[


### PR DESCRIPTION
#### Overview

A recent fix, #9, handled flat lines, but only for solid colours. Gradients would still render as invisible.

This fix, while not terribly elegant, is the best way to solve the problem, without causing any breaking or visible changes, and allowing for planned animations.